### PR TITLE
Smelting with non-Empty output Slot

### DIFF
--- a/src/main/java/com/Mrbysco/SlabMachines/tileentity/furnace/TileFurnaceSlab.java
+++ b/src/main/java/com/Mrbysco/SlabMachines/tileentity/furnace/TileFurnaceSlab.java
@@ -247,7 +247,7 @@ public class TileFurnaceSlab extends TileEntityFurnace implements ISlabFurnace{
             {
                 ItemStack itemstack1 = this.furnaceItemStacks.get(2);
 
-                if (itemstack1.isEmpty())
+                if (itemstack1.isEmpty() || itemstack1 == ItemStack.EMPTY)
                 {
                     return true;
                 }


### PR DESCRIPTION
# Smelting with non-Empty output Slot
![image](https://user-images.githubusercontent.com/20187163/60758474-61fa5b00-a017-11e9-91fc-3c4900ec0bd9.png)

This should fix the issue.